### PR TITLE
chore: Configure the issue template chooser #4

### DIFF
--- a/.github/ISSUE_TEMPLATES/config.yml
+++ b/.github/ISSUE_TEMPLATES/config.yml
@@ -3,3 +3,4 @@ contact_links:
   - name: Ask a Question or Discuss
     url: https://github.com/ioncakephper/cli-schema/discussions
     about: Please use GitHub Discussions for questions and support requests.
+    


### PR DESCRIPTION
Closes #4

This PR implements the configuration file for the issue template chooser at `.github/ISSUE_TEMPLATES/config.yml`.

This change disables blank issues and directs users with general questions to the GitHub Discussions page, improving the contribution experience.